### PR TITLE
Fixed PlayerEndOfMatch Missing match Error

### DIFF
--- a/dist/app/Http/Controllers/Api/Matchmaking/MatchmakingController.php
+++ b/dist/app/Http/Controllers/Api/Matchmaking/MatchmakingController.php
@@ -469,11 +469,6 @@ class MatchmakingController extends Controller
 
     protected function removeUserFromGame(User $user, Game $game)
     {
-        if($game->creator->id == $user->id) {
-            $game->delete();
-            return;
-        }
-
         $game->players()->detach($user);
 
         if($game->players->count() !== 0)


### PR DESCRIPTION
This should fix #14 

The game could sometimes be deleted when the host doesent send himself last for PlayerEndOfMatch.

Now the game only gets deleted when the last player was processed or the cleanup job deletes it.