### PR TITLE
Added Endpoint for the launcher to retrieve online/queued players.

### DIFF
--- a/Deathgarden Rebirth Bruno/Launcher/Get Online Players.bru
+++ b/Deathgarden Rebirth Bruno/Launcher/Get Online Players.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Online Players
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{base_url}}/api/online-players
+  body: none
+  auth: none
+}

--- a/dist/app/Console/Commands/CacheOnlinePlayerStats.php
+++ b/dist/app/Console/Commands/CacheOnlinePlayerStats.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\Game\Matchmaking\MatchmakingSide;
+use App\Http\Responses\Api\Statistics\OnlinePlayersResponse;
+use App\Models\Game\Matchmaking\QueuedPlayer;
+use DB;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class CacheOnlinePlayerStats extends Command
+{
+    const CACHE_KEY = 'online-players-response';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:cache-online-player-stats';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Caches the queued and in game players';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $queuedHunters = QueuedPlayer::whereSide(MatchmakingSide::Hunter)->count();
+        $queuedRunners = QueuedPlayer::whereSide(MatchmakingSide::Runner)->count();
+        $inGamePlayers = DB::table('game_user')->count();
+
+        Cache::set(self::CACHE_KEY, json_encode(new OnlinePlayersResponse(
+            $queuedRunners,
+            $queuedHunters,
+            $inGamePlayers,
+        )));
+    }
+}

--- a/dist/app/Http/Controllers/Api/StatisticsController.php
+++ b/dist/app/Http/Controllers/Api/StatisticsController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Console\Commands\CacheOnlinePlayerStats;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StatisticsController extends Controller
+{
+    public function getOnlinePlayers() {
+        return \Cache::get(CacheOnlinePlayerStats::CACHE_KEY);
+    }
+}

--- a/dist/app/Http/Responses/Api/Statistics/OnlinePlayersResponse.php
+++ b/dist/app/Http/Responses/Api/Statistics/OnlinePlayersResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Responses\Api\Statistics;
+
+use JsonSerializable;
+
+class OnlinePlayersResponse
+{
+    public function __construct(
+        public int $queuedRunners,
+        public int $queuedHunters,
+        public int $inGamePlayers,
+    )
+    {
+    }
+}

--- a/dist/routes/api.php
+++ b/dist/routes/api.php
@@ -29,6 +29,9 @@ Route::prefix('v1')->middleware('api.session')->group(function () {
     });
 });
 
+Route::get('online-players', [\App\Http\Controllers\Api\StatisticsController::class, 'getOnlinePlayers'])
+    ->name('api.online-players');
+
 Route::fallback(function () {
     return response('route not found', 404);
 })->middleware('api.session');


### PR DESCRIPTION
Added new endpoint `/api/online-players` for retrieving queued and in game players.

Example response:
```json
{
  "queuedRunners": 1,
  "queuedHunters": 2,
  "inGamePlayers": 0
}
```